### PR TITLE
Specify C++ standard in CMakeLists file in examples directory 

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.6)
 
+set(CMAKE_CXX_STANDARD 17)
+
 add_executable(fries_test fries_test.cpp)
 target_include_directories(fries_test PRIVATE "${CMAKE_INSTALL_PREFIX}/include")
 


### PR DESCRIPTION
Fix #1 